### PR TITLE
Feat: Add Claude Code skills documentation

### DIFF
--- a/.claude/skills/cli-commands.md
+++ b/.claude/skills/cli-commands.md
@@ -1,0 +1,225 @@
+---
+description: ML-Dash CLI commands for authentication, uploading, downloading, and listing experiments
+globs:
+  - "**/*.sh"
+  - "**/*.bash"
+  - "**/Makefile"
+  - "**/.github/**"
+keywords:
+  - ml-dash
+  - cli
+  - command line
+  - login
+  - logout
+  - upload
+  - download
+  - list
+  - authentication
+  - OAuth
+  - api-key
+  - sync
+  - batch
+---
+
+# ML-Dash CLI Commands
+
+## Installation Verification
+
+```bash
+ml-dash --help
+```
+
+## Authentication
+
+### Login (One-time Setup)
+```bash
+ml-dash login
+```
+Opens browser for OAuth2 authentication. Token stored in system keychain.
+
+### Custom Server
+```bash
+ml-dash login --remote https://your-server.com
+```
+
+### Logout
+```bash
+ml-dash logout
+```
+
+### API Key (CI/CD)
+```bash
+# Environment variable
+export ML_DASH_API_KEY="your-jwt-token"
+ml-dash upload
+
+# Or command line
+ml-dash upload --api-key your-jwt-token
+
+# Or config file ~/.ml-dash/config.json
+{"remote_url": "https://api.dash.ml", "api_key": "your-jwt-token"}
+```
+
+---
+
+## Upload Command
+
+Upload local experiments to remote server.
+
+```bash
+# Upload all from default .ml-dash directory
+ml-dash upload
+
+# Upload from specific directory
+ml-dash upload ./experiments
+
+# Filter by project
+ml-dash upload --project my-project
+
+# Filter by experiment
+ml-dash upload --project my-project --experiment specific-run
+
+# Dry run (preview only)
+ml-dash upload --dry-run --verbose
+
+# Resume interrupted upload
+ml-dash upload --resume
+```
+
+### Key Options
+- `--project`: Filter by project name
+- `--experiment`: Filter by experiment name
+- `--dry-run`: Preview without uploading
+- `--resume`: Continue from last state
+- `-v, --verbose`: Detailed output
+
+---
+
+## Download Command
+
+Download experiments from remote server.
+
+```bash
+# Download to directory
+ml-dash download ./data
+
+# Download specific project
+ml-dash download ./data --project my-project
+
+# Download specific experiment
+ml-dash download ./data --project my-project --experiment run-123
+
+# Skip certain data types
+ml-dash download ./data --skip-files
+ml-dash download ./data --skip-logs --skip-files --skip-params
+
+# Dry run
+ml-dash download ./data --dry-run --verbose
+
+# Resume interrupted download
+ml-dash download ./data --resume
+```
+
+### Performance Options
+```bash
+# Adjust parallelism
+ml-dash download --max-concurrent-metrics 10 --max-concurrent-files 5
+
+# Increase batch size (up to 10,000)
+ml-dash download --batch-size 10000
+```
+
+---
+
+## List Command
+
+Discover projects and experiments on remote server.
+
+```bash
+# List all projects
+ml-dash list
+
+# List experiments in project
+ml-dash list --project vision-models
+
+# Filter by status
+ml-dash list --project ml --status COMPLETED
+ml-dash list --project ml --status RUNNING
+ml-dash list --project ml --status FAILED
+
+# Filter by tags
+ml-dash list --project ml --tags baseline
+
+# Detailed output
+ml-dash list --project ml --detailed
+
+# JSON output (for scripting)
+ml-dash list --project ml --json
+```
+
+---
+
+## Common Workflows
+
+### Offline Development -> Upload
+```bash
+ml-dash login                # One-time auth
+python train.py              # Run experiments locally
+ml-dash upload               # Sync when internet available
+```
+
+### Download -> Analyze -> Re-upload
+```bash
+ml-dash download ./analysis --project training-runs
+python analyze.py            # Add metrics/files
+ml-dash upload ./analysis
+```
+
+### Backup and Migration
+```bash
+# Backup from production
+ml-dash login --remote https://prod.example.com
+ml-dash download ./backup
+
+# Restore to development
+ml-dash login --remote https://api.dash.ml
+ml-dash upload ./backup
+```
+
+### Discovery and Selective Download
+```bash
+ml-dash list                                    # See all projects
+ml-dash list --project vision-models            # See experiments
+ml-dash download ./data --project vision-models --experiment resnet-50
+```
+
+---
+
+## Global Options
+
+All commands support:
+- `--remote URL`: Remote server URL (default: https://api.dash.ml)
+- `--api-key TOKEN`: JWT auth token
+- `-v, --verbose`: Detailed output
+- `--help`: Command help
+
+---
+
+## Troubleshooting
+
+### Command Not Found
+```bash
+python -m ml_dash.cli --help
+# or with uv
+uv run python -m ml_dash.cli --help
+```
+
+### Authentication Errors
+```bash
+ml-dash logout && ml-dash login
+```
+
+### Resume Not Working
+Check state files exist:
+- `.ml-dash-upload-state.json`
+- `.ml-dash-download-state.json`

--- a/.claude/skills/experiment-setup.md
+++ b/.claude/skills/experiment-setup.md
@@ -1,0 +1,154 @@
+---
+description: Experiment class configuration, usage patterns, local vs remote modes, and lifecycle management
+globs:
+  - "**/*.py"
+  - "**/train*.py"
+  - "**/experiment*.py"
+keywords:
+  - Experiment
+  - context manager
+  - decorator
+  - local mode
+  - remote mode
+  - experiment lifecycle
+  - run.start
+  - run.complete
+  - run.fail
+  - status
+  - RUNNING
+  - COMPLETED
+  - FAILED
+---
+
+# ML-Dash Experiment Configuration
+
+## Three Usage Styles
+
+### Context Manager (Recommended)
+```python
+from ml_dash import Experiment
+
+with Experiment(name="my-experiment", project="project",
+        local_path=".ml-dash").run as experiment:
+    experiment.log("Training started")
+    experiment.params.set(learning_rate=0.001)
+    # Automatically closed on exit
+```
+
+### Decorator Style
+```python
+from ml_dash import ml_dash_experiment
+
+@ml_dash_experiment(name="my-experiment", project="project")
+def train_model(experiment):
+    experiment.params.set(learning_rate=0.001)
+    for epoch in range(10):
+        experiment.metrics("loss").append(value=0.5, epoch=epoch)
+    return "Training complete!"
+
+result = train_model()
+```
+
+### Direct (Manual Control)
+```python
+from ml_dash import Experiment
+
+experiment = Experiment(name="my-experiment", project="project",
+        local_path=".ml-dash")
+experiment.run.start()
+
+try:
+    experiment.params.set(learning_rate=0.001)
+finally:
+    experiment.run.complete()
+```
+
+## Local vs Remote Mode
+
+### Local Mode (Filesystem)
+```python
+with Experiment(
+    name="my-experiment",
+    project="project",
+    local_path=".ml-dash"  # Storage directory
+).run as experiment:
+    experiment.log("Using local storage")
+```
+
+### Remote Mode (Server)
+```python
+# First: ml-dash login
+with Experiment(
+    name="my-experiment",
+    project="project",
+    remote="https://api.dash.ml",
+    user_name="alice"
+).run as experiment:
+    experiment.log("Using remote server")
+```
+
+## Experiment Metadata
+
+```python
+with Experiment(
+    name="resnet50-imagenet",
+    project="computer-vision",
+    local_path=".ml-dash",
+    description="ResNet-50 training with new augmentation",
+    tags=["resnet", "imagenet", "baseline"],
+    bindrs=["gpu-cluster", "team-a"],
+    folder="/experiments/2025/resnet"
+).run as experiment:
+    pass
+```
+
+## Status Lifecycle
+
+- **RUNNING**: Set when experiment opens
+- **COMPLETED**: Set on normal exit
+- **FAILED**: Set on exception
+- **CANCELLED**: Set manually
+
+### Automatic Status Management
+```python
+# Normal completion -> COMPLETED
+with Experiment(name="training", project="ml",
+        remote="https://api.dash.ml").run as experiment:
+    experiment.log("Training...")
+
+# Exception -> FAILED
+with Experiment(name="training", project="ml",
+        remote="https://api.dash.ml").run as experiment:
+    raise ValueError("Training failed!")
+```
+
+### Manual Status Control
+```python
+experiment = Experiment(name="training", project="ml",
+        remote="https://api.dash.ml")
+experiment.run.start()
+
+try:
+    # training...
+    experiment.run.complete()
+except KeyboardInterrupt:
+    experiment.run.cancel()
+except Exception as e:
+    experiment.run.fail()
+```
+
+## Resuming Experiments
+
+Experiments use upsert behavior - reopen by using the same name:
+
+```python
+# First run
+with Experiment(name="long-training", project="ml",
+        local_path=".ml-dash").run as experiment:
+    experiment.metrics("loss").append(value=0.5, epoch=1)
+
+# Later - continues same experiment
+with Experiment(name="long-training", project="ml",
+        local_path=".ml-dash").run as experiment:
+    experiment.metrics("loss").append(value=0.3, epoch=2)
+```

--- a/.claude/skills/file-management.md
+++ b/.claude/skills/file-management.md
@@ -1,0 +1,203 @@
+---
+description: File uploads, downloads, artifacts, checkpoints, visualizations, and videos in ML-Dash
+globs:
+  - "**/*.py"
+  - "**/train*.py"
+  - "**/*checkpoint*"
+  - "**/*model*"
+keywords:
+  - files
+  - upload
+  - download
+  - artifact
+  - checkpoint
+  - save
+  - save_fig
+  - save_video
+  - save_torch
+  - model.pth
+  - visualization
+  - plot
+  - matplotlib
+---
+
+# ML-Dash File Management
+
+## Basic Upload
+
+```python
+result = experiment.files("model.pth", prefix="/models").save()
+
+print(f"Uploaded: {result['filename']}")
+print(f"Size: {result['sizeBytes']} bytes")
+print(f"Checksum: {result['checksum']}")
+```
+
+## Organizing Files with Prefixes
+
+```python
+# Models
+experiment.files("model.pth", prefix="/models").save()
+experiment.files("best_model.pth", prefix="/models/checkpoints").save()
+
+# Visualizations
+experiment.files("loss_curve.png", prefix="/visualizations").save()
+
+# Configuration
+experiment.files("config.json", prefix="/config").save()
+```
+
+## File Metadata
+
+```python
+experiment.files(
+    "best_model.pth",
+    prefix="/models",
+    description="Best model from epoch 50",
+    tags=["checkpoint", "best"],
+    metadata={
+        "epoch": 50,
+        "val_accuracy": 0.95
+    }
+).save()
+```
+
+## Downloading Files
+
+```python
+# Upload first
+upload_result = experiment.files("model.pth", prefix="/models").save()
+file_id = upload_result["id"]
+
+# Download to specific path
+downloaded = experiment.files(
+    file_id=file_id,
+    dest_path="./downloaded_model.pth"
+).download()
+
+# Download with original filename
+downloaded = experiment.files(file_id=file_id).download()
+```
+
+## List and Download
+
+```python
+files = experiment.files().list()
+
+for f in files:
+    print(f"File: {f['filename']}, Path: {f['path']}, Size: {f['sizeBytes']}")
+
+# Download specific file
+best = next((f for f in files if "best" in f.get("tags", [])), None)
+if best:
+    experiment.files(file_id=best["id"], dest_path="./best.pth").download()
+```
+
+## Saving Matplotlib Figures
+
+```python
+import matplotlib.pyplot as plt
+
+plt.plot([0.5, 0.4, 0.3, 0.2])
+plt.title("Training Loss")
+
+# save_fig auto-closes figure
+experiment.files(prefix="/visualizations").save_fig("loss_curve.png")
+
+# With custom options
+experiment.files(prefix="/visualizations").save_fig(
+    "plot.pdf",
+    dpi=150,
+    transparent=True,
+    bbox_inches='tight'
+)
+```
+
+## Saving Videos
+
+```python
+import numpy as np
+
+# Generate frames (list of arrays or stacked array)
+frames = [np.random.rand(480, 640, 3) for _ in range(30)]
+
+# Save as MP4 (default 20 FPS)
+experiment.files(prefix="/videos").save_video(frames, "animation.mp4")
+
+# Custom FPS
+experiment.files(prefix="/videos").save_video(frames, "animation.mp4", fps=30)
+
+# Save as GIF
+experiment.files(prefix="/videos").save_video(frames, "animation.gif")
+```
+
+### Frame Format Support
+- Grayscale: (H, W)
+- RGB: (H, W, 3)
+- Stacked: (N, H, W) or (N, H, W, C)
+- Float 0-1 auto-scaled to 0-255
+
+## Saving PyTorch Models
+
+```python
+# Using the singleton
+from ml_dash import dxp
+
+dxp.files.save_torch(model, "model.pt")
+dxp.files.save_torch(model.state_dict(), "model_state.pt")
+```
+
+## Training Checkpoint Pattern
+
+```python
+import torch
+
+best_accuracy = 0.0
+
+for epoch in range(100):
+    train_loss = train_one_epoch(model)
+    val_accuracy = validate(model)
+
+    experiment.metrics("train_loss").append(value=train_loss, epoch=epoch)
+    experiment.metrics("val_accuracy").append(value=val_accuracy, epoch=epoch)
+
+    # Save checkpoint every 10 epochs
+    if (epoch + 1) % 10 == 0:
+        torch.save(model.state_dict(), f"checkpoint_{epoch+1}.pth")
+        experiment.files(
+            f"checkpoint_{epoch+1}.pth",
+            prefix="/checkpoints",
+            tags=["checkpoint"],
+            metadata={"epoch": epoch + 1}
+        ).save()
+
+    # Save best model
+    if val_accuracy > best_accuracy:
+        best_accuracy = val_accuracy
+        torch.save(model.state_dict(), "best_model.pth")
+        experiment.files(
+            "best_model.pth",
+            prefix="/models",
+            description=f"Best (acc: {best_accuracy:.4f})",
+            tags=["best"],
+            metadata={"epoch": epoch + 1, "accuracy": best_accuracy}
+        ).save()
+```
+
+## Storage Structure
+
+### Local Mode
+```
+files/
+├── models/
+│   └── {snowflake_id}/model.pth
+├── checkpoints/
+│   └── {snowflake_id}/checkpoint.pth
+└── visualizations/
+    └── {snowflake_id}/plot.png
+```
+
+### Remote Mode
+- Files: S3 `s3://bucket/files/{namespace}/{project}/{experiment}/{prefix}/{file_id}/filename`
+- Metadata: MongoDB (path, size, SHA256 checksum, tags)
+- File size limit: 5GB

--- a/.claude/skills/getting-started.md
+++ b/.claude/skills/getting-started.md
@@ -1,0 +1,91 @@
+---
+description: ML-Dash installation, quick start, and basic usage patterns
+globs:
+  - "**/*.py"
+  - "**/requirements*.txt"
+  - "**/pyproject.toml"
+  - "**/setup.py"
+keywords:
+  - install
+  - setup
+  - getting started
+  - quick start
+  - pip install
+  - uv add
+  - ml-dash
+  - dxp
+  - import ml_dash
+---
+
+# ML-Dash Getting Started
+
+## Installation
+
+```bash
+pip install ml-dash
+# or
+uv add ml-dash
+```
+
+## Quick Start - Remote Mode (Recommended)
+
+### 1. Authenticate
+```bash
+ml-dash login
+```
+Opens browser for secure OAuth2 authentication. Token stored in system keychain.
+
+### 2. Start Tracking
+
+```python
+from ml_dash import dxp
+
+with dxp.run:
+    dxp.log().info("Training started")
+    dxp.params.set(learning_rate=0.001, batch_size=32)
+
+    for epoch in range(10):
+        loss = 1.0 - epoch * 0.08
+        dxp.metrics("loss").append(value=loss, epoch=epoch)
+
+    dxp.log().info("Training completed")
+```
+
+## Quick Start - Local Mode (No Auth)
+
+```python
+from ml_dash import Experiment
+
+with Experiment(name="my-experiment", project="tutorial",
+        local_path=".ml-dash").run as experiment:
+    experiment.log().info("Training started")
+    experiment.params.set(learning_rate=0.001, batch_size=32)
+
+    for epoch in range(10):
+        loss = 1.0 - epoch * 0.08
+        experiment.metrics("loss").append(value=loss, epoch=epoch)
+```
+
+Data stored in `.ml-dash/tutorial/my-experiment/`.
+
+## Pre-configured Singleton (dxp)
+
+```python
+from ml_dash import dxp  # or from ml_dash.auto_start import dxp
+
+# Ready to use immediately
+dxp.params.set(learning_rate=0.001)
+dxp.metrics.append(loss=0.5, accuracy=0.9)
+dxp.files.save_torch(model, "model.pt")
+```
+
+## Data Storage Structure
+
+```
+.ml-dash/
+└── project/
+    └── experiment/
+        ├── logs/logs.jsonl
+        ├── parameters/parameters.json
+        └── metrics/loss.jsonl
+```

--- a/.claude/skills/tracking-data.md
+++ b/.claude/skills/tracking-data.md
@@ -1,0 +1,206 @@
+---
+description: Tracking parameters, metrics, and logs in ML-Dash experiments
+globs:
+  - "**/*.py"
+  - "**/train*.py"
+  - "**/config*.py"
+keywords:
+  - params
+  - parameters
+  - hyperparameters
+  - metrics
+  - log
+  - logging
+  - append
+  - append_batch
+  - set
+  - time series
+  - loss
+  - accuracy
+---
+
+# ML-Dash Data Tracking
+
+## Parameters (Hyperparameters)
+
+### Basic Usage
+```python
+experiment.params.set(
+    learning_rate=0.001,
+    batch_size=32,
+    optimizer="adam",
+    epochs=100
+)
+```
+
+### Nested Parameters (Auto-flattened)
+```python
+experiment.params.set(**{
+    "model": {
+        "architecture": "resnet50",
+        "pretrained": True
+    },
+    "optimizer": {
+        "type": "adam",
+        "lr": 0.001
+    }
+})
+# Stored as: model.architecture, model.pretrained, optimizer.type, etc.
+```
+
+### From Config Files
+```python
+import json
+with open("config.json") as f:
+    config = json.load(f)
+experiment.params.set(**config)
+```
+
+### From argparse
+```python
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("--lr", type=float, default=0.001)
+args = parser.parse_args()
+experiment.params.set(**vars(args))
+```
+
+### From Dataclass
+```python
+from dataclasses import dataclass, asdict
+
+@dataclass
+class Config:
+    learning_rate: float = 0.001
+    batch_size: int = 32
+
+experiment.params.set(**asdict(Config()))
+```
+
+---
+
+## Metrics (Time Series)
+
+### Basic Usage
+```python
+experiment.metrics("train_loss").append(value=0.5, epoch=1)
+experiment.metrics("accuracy").append(value=0.85, step=100, epoch=1)
+```
+
+### Flexible Schema
+```python
+# Multiple fields per point
+experiment.metrics("metrics").append(
+    loss=0.5,
+    accuracy=0.85,
+    learning_rate=0.001,
+    epoch=1
+)
+
+# With timestamp
+import time
+experiment.metrics("system").append(
+    cpu_percent=45.2,
+    memory_mb=1024,
+    timestamp=time.time()
+)
+```
+
+### Batch Append (Better Performance)
+```python
+experiment.metrics("train_loss").append_batch([
+    {"value": 0.5, "step": 1, "epoch": 1},
+    {"value": 0.45, "step": 2, "epoch": 1},
+    {"value": 0.40, "step": 3, "epoch": 1},
+])
+```
+
+### Batch Collection Pattern
+```python
+batch = []
+for step in range(1000):
+    loss = train_step()
+    batch.append({"value": loss, "step": step})
+
+    if len(batch) >= 100:
+        experiment.metrics("train_loss").append_batch(batch)
+        batch = []
+
+if batch:  # Remaining
+    experiment.metrics("train_loss").append_batch(batch)
+```
+
+### Reading Metrics
+```python
+result = experiment.metrics("loss").read(start_index=0, limit=10)
+for point in result['data']:
+    print(f"Index {point['index']}: {point['data']}")
+```
+
+---
+
+## Logging
+
+### Basic Usage
+```python
+experiment.log("Training started")
+experiment.log("Model: ResNet-50", level="info")
+experiment.log("GPU memory low", level="warn")
+experiment.log("Failed to load", level="error")
+```
+
+### Log Levels
+`debug`, `info` (default), `warn`, `error`, `fatal`
+
+### Structured Metadata
+```python
+experiment.log(
+    "Epoch completed",
+    level="info",
+    metadata={
+        "epoch": 5,
+        "train_loss": 0.234,
+        "val_loss": 0.456
+    }
+)
+```
+
+### Training Loop Pattern
+```python
+for epoch in range(10):
+    train_loss = train_one_epoch()
+    val_loss = validate()
+
+    experiment.log(
+        f"Epoch {epoch + 1} complete",
+        level="info",
+        metadata={"train_loss": train_loss, "val_loss": val_loss}
+    )
+```
+
+### Error Tracking
+```python
+try:
+    result = risky_operation()
+except Exception as e:
+    experiment.log(
+        f"Operation failed: {e}",
+        level="error",
+        metadata={"error_type": type(e).__name__}
+    )
+    raise
+```
+
+---
+
+## Storage Format
+
+### Local Mode
+- Parameters: `parameters/parameters.json`
+- Metrics: `metrics/{name}/data.jsonl`
+- Logs: `logs/logs.jsonl`
+
+### Remote Mode
+- Parameters: MongoDB document
+- Metrics: MongoDB (hot) + S3 (cold, after 10K points)
+- Logs: MongoDB with timestamp/level indexing

--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,9 @@ tmp/
 # OS
 Thumbs.db
 
-# Claude
+# Claude (keep skills/, ignore settings)
 .claude/
+!.claude/skills/
 
 .ml-logger-test
 .ml-loggertest/test_save_pkl.py


### PR DESCRIPTION
## Summary
- Add `.claude/skills/` directory with 5 skill documentation files
- Each skill has intelligent YAML frontmatter for fast retrieval (description, globs, keywords)
- Skills cover: getting started, experiments, tracking data, files, and CLI

## Skill Files
| File | Purpose |
|------|---------|
| `getting-started.md` | Installation, quick start, basic usage patterns |
| `experiment-setup.md` | Experiment class, local/remote modes, lifecycle |
| `tracking-data.md` | Parameters, metrics, and logging APIs |
| `file-management.md` | File uploads, checkpoints, visualizations, videos |
| `cli-commands.md` | Authentication, upload, download, list commands |

## Frontmatter Structure
Each file includes YAML frontmatter with:
- `description`: Clear purpose for Claude to understand the skill
- `globs`: File patterns (e.g., `**/*.py`) for context matching
- `keywords`: Search terms for quick retrieval

## Test Plan
- [ ] Verify skills are discoverable by Claude Code
- [ ] Test keyword matching for common queries
- [ ] Confirm code examples are accurate

cc @tomtao57

🤖 Generated with [Claude Code](https://claude.com/claude-code)