### PR TITLE
Feat: New files API with path-based access and glob patterns (v0.6.2rc1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ A simple and flexible SDK for ML experiment tracking and data storage.
 <td>
 
 ```bash
-uv add ml-dash
+uv add ml-dash==0.6.2rc1
 ```
 
 </td>
 <td>
 
 ```bash
-pip install ml-dash
+pip install ml-dash==0.6.2rc1
 ```
 
 </td>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ Get started with ML-Dash in under 5 minutes.
 ## Installation
 
 ```bash
-pip install ml-dash
+pip install ml-dash==0.6.2rc1
 ```
 
 ## Quick Start with Remote Mode

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,13 +3,13 @@
 You can install the package with uv or pip:
 
 ```shell
-uv add ml-dash
+uv add ml-dash==0.6.2rc1
 ```
 
 or
 
 ```shell
-pip install ml-dash
+pip install ml-dash==0.6.2rc1
 ```
 
 The core of ML-Dash is the `Experiment` class. It supports logging, upload, and download of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml-dash"
-version = "0.6.1"
+version = "0.6.2rc1"
 description = "ML experiment tracking and data storage"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -31,6 +31,7 @@ dependencies = [
     "scikit-image>=0.21.0",
     "rich>=13.0.0",
     "cryptography>=42.0.0",
+    "params-proto>=3.0.0rc12",
 ]
 
 [project.scripts]

--- a/src/ml_dash/__init__.py
+++ b/src/ml_dash/__init__.py
@@ -51,6 +51,7 @@ from .client import RemoteClient
 from .storage import LocalStorage
 from .log import LogLevel, LogBuilder
 from .params import ParametersBuilder
+from .run import RUN
 from .auto_start import dxp
 
 __version__ = "0.1.0"
@@ -65,6 +66,7 @@ __all__ = [
     "LogLevel",
     "LogBuilder",
     "ParametersBuilder",
+    "RUN",
     "dxp",
 ]
 

--- a/src/ml_dash/run.py
+++ b/src/ml_dash/run.py
@@ -1,0 +1,85 @@
+"""
+RUN - Global run configuration object for ML-Dash.
+
+This module provides a global RUN object that serves as the single source
+of truth for run/experiment metadata. Uses params-proto for configuration.
+
+Usage:
+    from ml_dash import RUN
+
+    # Configure the run
+    RUN.name = "my-experiment"
+    RUN.project = "my-project"
+
+    # Use in templates
+    folder = "/experiments/{RUN.name}".format(RUN=RUN)
+
+    # With dxp singleton (RUN is auto-populated)
+    from ml_dash import dxp
+    with dxp.run:
+        # RUN.name, RUN.project, RUN.id, RUN.timestamp are set
+        dxp.log().info(f"Running {RUN.name}")
+"""
+
+from datetime import datetime
+from params_proto import proto
+
+
+@proto.prefix
+class RUN:
+    """
+    Global run configuration.
+
+    This class is the single source of truth for run metadata.
+    Configure it before starting an experiment, or let dxp auto-configure.
+    """
+    # Core identifiers
+    name: str = "untitled"  # Run/experiment name
+    project: str = "scratch"  # Project name
+
+    # Auto-generated identifiers (populated at run.start())
+    id: str = None  # Unique run ID (auto-generated)
+    timestamp: str = None  # Run timestamp (same as id)
+
+    # Optional configuration
+    folder: str = None  # Folder path with optional templates
+    description: str = None  # Run description
+
+    @classmethod
+    def _generate_id(cls) -> str:
+        """Generate a unique run ID based on current timestamp."""
+        return datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+    @classmethod
+    def _init_run(cls) -> None:
+        """Initialize run ID and timestamp if not already set."""
+        if cls.id is None:
+            cls.id = cls._generate_id()
+            cls.timestamp = cls.id
+
+    @classmethod
+    def _format(cls, template: str) -> str:
+        """
+        Format a template string with RUN values.
+
+        Args:
+            template: String with {RUN.attr} placeholders
+
+        Returns:
+            Formatted string with placeholders replaced
+
+        Example:
+            RUN._format("/experiments/{RUN.name}_{RUN.id}")
+            # -> "/experiments/my-exp_20241219_143022"
+        """
+        return template.format(RUN=cls)
+
+    @classmethod
+    def _reset(cls) -> None:
+        """Reset RUN to defaults (for testing or new runs)."""
+        cls.name = "untitled"
+        cls.project = "scratch"
+        cls.id = None
+        cls.timestamp = None
+        cls.folder = None
+        cls.description = None

--- a/src/ml_dash/storage.py
+++ b/src/ml_dash/storage.py
@@ -627,7 +627,8 @@ class LocalStorage:
             FileNotFoundError: If file not found
         """
         experiment_dir = self._get_experiment_dir(project, experiment)
-        metadata_file = experiment_dir / "files" / ".files_metadata.json"
+        files_dir = experiment_dir / "files"
+        metadata_file = files_dir / ".files_metadata.json"
 
         if not metadata_file.exists():
             raise FileNotFoundError(f"File {file_id} not found")
@@ -689,7 +690,8 @@ class LocalStorage:
             FileNotFoundError: If file not found
         """
         experiment_dir = self._get_experiment_dir(project, experiment)
-        metadata_file = experiment_dir / "files" / ".files_metadata.json"
+        files_dir = experiment_dir / "files"
+        metadata_file = files_dir / ".files_metadata.json"
 
         if not metadata_file.exists():
             raise FileNotFoundError(f"File {file_id} not found")

--- a/test/test_files_new_api.py
+++ b/test/test_files_new_api.py
@@ -1,0 +1,383 @@
+"""Tests for the new fluent file operations API."""
+import json
+import pytest
+import hashlib
+from pathlib import Path
+
+
+class TestFluentFileSave:
+    """Tests for the new fluent save() API."""
+
+    def test_save_existing_file_path(self, local_experiment, sample_files):
+        """Test saving an existing file using path argument."""
+        with local_experiment(name="fluent-save-file", project="test").run as exp:
+            result = exp.files("models").save(sample_files["model"])
+
+            assert result["filename"] == "model.txt"
+            assert result["path"] == "/models"
+            assert result["sizeBytes"] > 0
+            assert "checksum" in result
+
+    def test_save_with_to_parameter(self, local_experiment, tmp_path):
+        """Test saving bytes with to parameter."""
+        with local_experiment(name="fluent-save-to", project="test").run as exp:
+            result = exp.files("data").save(b"hello world", to="greeting.bin")
+
+            assert result["filename"] == "greeting.bin"
+            assert result["path"] == "/data"
+
+    def test_save_dict_as_json(self, local_experiment, tmp_path):
+        """Test saving dict as JSON."""
+        with local_experiment(name="fluent-save-json", project="test").run as exp:
+            config = {"model": "resnet50", "lr": 0.001}
+            result = exp.files("configs").save(config, to="config.json")
+
+            assert result["filename"] == "config.json"
+            assert result["path"] == "/configs"
+
+            # Verify we can download and read it
+            downloaded = exp.files(file_id=result["id"]).download()
+            content = json.loads(Path(downloaded).read_text())
+            assert content == config
+
+    def test_save_list_as_json(self, local_experiment):
+        """Test saving list as JSON."""
+        with local_experiment(name="fluent-save-list", project="test").run as exp:
+            data = [1, 2, 3, {"key": "value"}]
+            result = exp.files("data").save(data, to="array.json")
+
+            assert result["filename"] == "array.json"
+
+    def test_files_save_direct(self, local_experiment, sample_files):
+        """Test experiment.files.save() direct method."""
+        with local_experiment(name="fluent-direct-save", project="test").run as exp:
+            result = exp.files.save(sample_files["model"])
+
+            assert result["filename"] == "model.txt"
+
+    def test_files_save_with_path(self, local_experiment):
+        """Test experiment.files.save() with to parameter including path."""
+        with local_experiment(name="fluent-direct-save-path", project="test").run as exp:
+            result = exp.files.save({"key": "value"}, to="configs/settings.json")
+
+            assert result["filename"] == "settings.json"
+            assert result["path"] == "/configs"
+
+
+class TestFluentSaveText:
+    """Tests for save_text() method."""
+
+    def test_save_text_basic(self, local_experiment, tmp_path):
+        """Test basic save_text usage."""
+        with local_experiment(name="save-text", project="test").run as exp:
+            content = "Hello, World!\nThis is a test."
+            result = exp.files("texts").save_text(content, to="greeting.txt")
+
+            assert result["filename"] == "greeting.txt"
+            assert result["path"] == "/texts"
+
+            # Download and verify
+            downloaded = exp.files(file_id=result["id"]).download()
+            assert Path(downloaded).read_text() == content
+
+    def test_save_text_direct(self, local_experiment):
+        """Test experiment.files.save_text() direct method."""
+        with local_experiment(name="save-text-direct", project="test").run as exp:
+            result = exp.files.save_text("content", to="file.txt")
+
+            assert result["filename"] == "file.txt"
+
+    def test_save_text_with_path(self, local_experiment):
+        """Test save_text with path including prefix."""
+        with local_experiment(name="save-text-path", project="test").run as exp:
+            result = exp.files.save_text("yaml: content", to="configs/view.yaml")
+
+            assert result["filename"] == "view.yaml"
+            assert result["path"] == "/configs"
+
+
+class TestFluentSaveJson:
+    """Tests for save_json() method."""
+
+    def test_save_json_dict(self, local_experiment, tmp_path):
+        """Test save_json with dict."""
+        with local_experiment(name="save-json-dict", project="test").run as exp:
+            data = {"hey": "yo", "count": 42}
+            result = exp.files("configs").save_json(data, to="config.json")
+
+            assert result["filename"] == "config.json"
+
+            # Download and verify
+            downloaded = exp.files(file_id=result["id"]).download()
+            content = json.loads(Path(downloaded).read_text())
+            assert content == data
+
+    def test_save_json_direct(self, local_experiment):
+        """Test experiment.files.save_json() direct method."""
+        with local_experiment(name="save-json-direct", project="test").run as exp:
+            result = exp.files.save_json({"key": "value"}, to="data.json")
+
+            assert result["filename"] == "data.json"
+
+
+class TestFluentSaveBlob:
+    """Tests for save_blob() method."""
+
+    def test_save_blob_basic(self, local_experiment, tmp_path):
+        """Test basic save_blob usage."""
+        with local_experiment(name="save-blob", project="test").run as exp:
+            data = b"\x00\x01\x02\x03\x04\x05"
+            result = exp.files("data").save_blob(data, to="binary.bin")
+
+            assert result["filename"] == "binary.bin"
+            assert result["sizeBytes"] == 6
+
+            # Download and verify
+            downloaded = exp.files(file_id=result["id"]).download()
+            assert Path(downloaded).read_bytes() == data
+
+    def test_save_blob_direct(self, local_experiment):
+        """Test experiment.files.save_blob() direct method."""
+        with local_experiment(name="save-blob-direct", project="test").run as exp:
+            result = exp.files.save_blob(b"data", to="file.bin")
+
+            assert result["filename"] == "file.bin"
+
+
+class TestFluentList:
+    """Tests for fluent list() API."""
+
+    def test_list_all(self, local_experiment, sample_files):
+        """Test listing all files."""
+        with local_experiment(name="list-all", project="test").run as exp:
+            exp.files("models").save(sample_files["model"])
+            exp.files("configs").save(sample_files["config"])
+
+            files = exp.files().list()
+
+            assert len(files) == 2
+            filenames = [f["filename"] for f in files]
+            assert "model.txt" in filenames
+            assert "config.json" in filenames
+
+    def test_list_by_prefix(self, local_experiment, sample_files):
+        """Test listing files by prefix."""
+        with local_experiment(name="list-prefix", project="test").run as exp:
+            exp.files("models").save(sample_files["model"])
+            exp.files("configs").save(sample_files["config"])
+            exp.files("models").save(sample_files["results"])
+
+            # List only models
+            files = exp.files("models").list()
+
+            assert len(files) == 2
+
+    def test_list_with_glob_pattern(self, local_experiment, sample_files):
+        """Test listing with glob pattern."""
+        with local_experiment(name="list-glob", project="test").run as exp:
+            exp.files("data").save(sample_files["model"])  # .txt
+            exp.files("data").save(sample_files["config"])  # .json
+            exp.files("data").save(sample_files["results"])  # .csv
+
+            # List only JSON files
+            json_files = exp.files("data").list("*.json")
+            assert len(json_files) == 1
+            assert json_files[0]["filename"] == "config.json"
+
+            # List txt files
+            txt_files = exp.files("data").list("*.txt")
+            assert len(txt_files) == 1
+
+    def test_list_direct_with_pattern(self, local_experiment, sample_files):
+        """Test experiment.files.list() with pattern."""
+        with local_experiment(name="list-direct", project="test").run as exp:
+            exp.files("models").save(sample_files["model"])
+            exp.files("configs").save(sample_files["config"])
+
+            files = exp.files.list("*.txt")
+            assert len(files) == 1
+
+
+class TestFluentDownload:
+    """Tests for fluent download() API."""
+
+    def test_download_by_path(self, local_experiment, sample_files, tmp_path):
+        """Test downloading file by path."""
+        with local_experiment(name="download-path", project="test").run as exp:
+            exp.files("models").save(sample_files["model"])
+
+            # Download by filename
+            downloaded = exp.files("model.txt").download(to=str(tmp_path / "out.txt"))
+
+            assert Path(downloaded).exists()
+            assert Path(downloaded).read_text() == Path(sample_files["model"]).read_text()
+
+    def test_download_with_pattern(self, local_experiment, sample_files, tmp_path):
+        """Test downloading multiple files with pattern."""
+        with local_experiment(name="download-pattern", project="test").run as exp:
+            exp.files("data").save(sample_files["model"])  # .txt
+            exp.files("data").save(sample_files["config"])  # .json
+
+            # Download all files matching pattern
+            dest_dir = tmp_path / "downloads"
+            downloaded = exp.files("data").download("*.txt", to=str(dest_dir))
+
+            assert isinstance(downloaded, list)
+            assert len(downloaded) == 1
+            assert Path(downloaded[0]).exists()
+
+    def test_download_direct_single(self, local_experiment, sample_files, tmp_path):
+        """Test experiment.files.download() for single file."""
+        with local_experiment(name="download-direct", project="test").run as exp:
+            exp.files("models").save(sample_files["model"])
+
+            downloaded = exp.files.download("model.txt", to=str(tmp_path / "out.txt"))
+
+            assert Path(downloaded).exists()
+
+    def test_download_direct_with_pattern(self, local_experiment, sample_files, tmp_path):
+        """Test experiment.files.download() with glob pattern."""
+        with local_experiment(name="download-direct-glob", project="test").run as exp:
+            exp.files("images").save(sample_files["model"])
+            exp.files("images").save(sample_files["config"])
+
+            # Download using path/pattern syntax
+            dest_dir = tmp_path / "local_images"
+            downloaded = exp.files.download("images/*.txt", to=str(dest_dir))
+
+            assert isinstance(downloaded, list)
+            assert len(downloaded) == 1
+
+
+class TestFluentDelete:
+    """Tests for fluent delete() API."""
+
+    def test_delete_by_path(self, local_experiment, sample_files):
+        """Test deleting file by path."""
+        with local_experiment(name="delete-path", project="test").run as exp:
+            exp.files("models").save(sample_files["model"])
+
+            files_before = exp.files().list()
+            assert len(files_before) == 1
+
+            # Delete by filename
+            result = exp.files("model.txt").delete()
+
+            assert "deletedAt" in result or "id" in result
+
+    def test_delete_with_pattern(self, local_experiment, sample_files):
+        """Test deleting multiple files with pattern."""
+        with local_experiment(name="delete-pattern", project="test").run as exp:
+            exp.files("data").save(sample_files["model"])  # .txt
+            exp.files("data").save(sample_files["config"])  # .json
+            exp.files("data").save(sample_files["results"])  # .csv
+
+            # Delete all txt files
+            results = exp.files("data").delete("*.txt")
+
+            assert isinstance(results, list)
+            assert len(results) == 1
+
+    def test_delete_direct(self, local_experiment, sample_files):
+        """Test experiment.files.delete() direct method."""
+        with local_experiment(name="delete-direct", project="test").run as exp:
+            exp.files("models").save(sample_files["model"])
+
+            result = exp.files.delete("model.txt")
+
+            assert "deletedAt" in result or "id" in result
+
+    def test_delete_with_path_pattern(self, local_experiment, sample_files):
+        """Test experiment.files.delete() with path/pattern."""
+        with local_experiment(name="delete-direct-glob", project="test").run as exp:
+            exp.files("images").save(sample_files["model"])
+            exp.files("images").save(sample_files["config"])
+
+            results = exp.files.delete("images/*.txt")
+
+            assert isinstance(results, list)
+
+
+class TestBackwardsCompatibility:
+    """Tests to ensure backwards compatibility with old API."""
+
+    def test_old_api_file_path_prefix(self, local_experiment, sample_files):
+        """Test old API with file_path and prefix kwargs still works."""
+        with local_experiment(name="compat-upload", project="test").run as exp:
+            result = exp.files(
+                file_path=sample_files["model"],
+                prefix="/models",
+                description="Model weights",
+                tags=["model"]
+            ).save()
+
+            assert result["filename"] == "model.txt"
+            assert result["path"] == "/models"
+
+    def test_old_api_download_by_file_id(self, local_experiment, sample_files, tmp_path):
+        """Test old API download with file_id still works."""
+        with local_experiment(name="compat-download", project="test").run as exp:
+            upload_result = exp.files(
+                file_path=sample_files["model"],
+                prefix="/models"
+            ).save()
+
+            file_id = upload_result["id"]
+
+            # Old API download
+            downloaded = exp.files(
+                file_id=file_id,
+                dest_path=str(tmp_path / "model.txt")
+            ).download()
+
+            assert Path(downloaded).exists()
+
+    def test_old_api_delete_by_file_id(self, local_experiment, sample_files):
+        """Test old API delete with file_id still works."""
+        with local_experiment(name="compat-delete", project="test").run as exp:
+            upload_result = exp.files(
+                file_path=sample_files["model"],
+                prefix="/models"
+            ).save()
+
+            file_id = upload_result["id"]
+
+            # Old API delete
+            result = exp.files(file_id=file_id).delete()
+
+            assert "deletedAt" in result or "id" in result
+
+    def test_old_api_list_with_prefix(self, local_experiment, sample_files):
+        """Test old API list with prefix still works."""
+        with local_experiment(name="compat-list", project="test").run as exp:
+            exp.files(file_path=sample_files["model"], prefix="/models").save()
+            exp.files(file_path=sample_files["config"], prefix="/configs").save()
+
+            # Old API list with prefix
+            files = exp.files(prefix="/models").list()
+
+            assert len(files) == 1
+            assert files[0]["filename"] == "model.txt"
+
+
+class TestBindrs:
+    """Tests for bindrs (file collections)."""
+
+    def test_bindrs_list_placeholder(self, local_experiment, sample_files):
+        """Test bindrs.list() placeholder functionality."""
+        with local_experiment(name="bindrs-test", project="test").run as exp:
+            # Upload files - bindrs filtering will return empty for now
+            # as bindrs metadata isn't set on files
+            exp.files("models").save(sample_files["model"])
+
+            # This should work but return empty (placeholder)
+            files = exp.bindrs("my-bindr").list()
+
+            # Placeholder returns empty list (no files have this bindr)
+            assert isinstance(files, list)
+
+
+if __name__ == "__main__":
+    """Run all tests with pytest."""
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,24 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
+name = "argparse"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/argparse-1.4.0.tar.gz", hash = "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4", size = 70508, upload-time = "2015-09-12T20:22:16.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/94/3af39d34be01a24a6e65433d19e107099374224905f1e0cc6bbe1fd22a2f/argparse-1.4.0-py2.py3-none-any.whl", hash = "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314", size = 23000, upload-time = "2015-09-14T16:03:16.137Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -431,6 +449,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "expandvars"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/64/a9d8ea289d663a44b346203a24bf798507463db1e76679eaa72ee6de1c7a/expandvars-1.1.2.tar.gz", hash = "sha256:6c5822b7b756a99a356b915dd1267f52ab8a4efaa135963bd7f4bd5d368f71d7", size = 70842, upload-time = "2025-09-12T10:55:20.929Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/e6/79c43f7a55264e479a9fbf21ddba6a73530b3ea8439a8bb7fa5a281721af/expandvars-1.1.2-py3-none-any.whl", hash = "sha256:d1652fe4e61914f5b88ada93aaedb396446f55ae4621de45c8cb9f66e5712526", size = 7526, upload-time = "2025-09-12T10:55:18.779Z" },
 ]
 
 [[package]]
@@ -823,13 +850,14 @@ wheels = [
 
 [[package]]
 name = "ml-dash"
-version = "0.6.0"
+version = "0.6.2rc1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
+    { name = "params-proto" },
     { name = "pyjwt" },
     { name = "rich" },
     { name = "scikit-image", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -876,6 +904,7 @@ requires-dist = [
     { name = "linkify-it-py", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+    { name = "params-proto", specifier = ">=3.0.0rc12" },
     { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
@@ -1252,6 +1281,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "params-proto"
+version = "3.0.0rc14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "argparse" },
+    { name = "expandvars" },
+    { name = "termcolor", version = "3.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "termcolor", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "waterbear" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/10/f9735c73395a16c76bbfb58383d565a40dca63b59117edb3c1fa3daff6d2/params_proto-3.0.0rc14.tar.gz", hash = "sha256:ef6795137464a29f3f44f1aa557778220377a97c995481d6f624d8021792894d", size = 946770, upload-time = "2025-12-18T20:46:16.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4c/98c39e7ac670728d94f98ecf9fbb1cbba093b512d50ab1e83fae8a45a74f/params_proto-3.0.0rc14-py3-none-any.whl", hash = "sha256:5e4a8ba69ae78f3b4786f60746ae6bc92964ce81cbc1fac19c659dd145df2d7f", size = 57327, upload-time = "2025-12-18T20:46:14.562Z" },
 ]
 
 [[package]]
@@ -2362,6 +2408,31 @@ wheels = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/6c/3d75c196ac07ac8749600b60b03f4f6094d54e132c4d94ebac6ee0e0add0/termcolor-3.1.0.tar.gz", hash = "sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970", size = 14324, upload-time = "2025-04-30T11:37:53.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl", hash = "sha256:591dd26b5c2ce03b9e43f391264626557873ce1d379019786f99b0c2bee140aa", size = 7684, upload-time = "2025-04-30T11:37:52.382Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/56/ab275c2b56a5e2342568838f0d5e3e66a32354adcc159b495e374cda43f5/termcolor-3.2.0.tar.gz", hash = "sha256:610e6456feec42c4bcd28934a8c87a06c3fa28b01561d46aa09a9881b8622c58", size = 14423, upload-time = "2025-10-25T19:11:42.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/d5/141f53d7c1eb2a80e6d3e9a390228c3222c27705cbe7f048d3623053f3ca/termcolor-3.2.0-py3-none-any.whl", hash = "sha256:a10343879eba4da819353c55cb8049b0933890c2ebf9ad5d3ecd2bb32ea96ea6", size = 7698, upload-time = "2025-10-25T19:11:41.536Z" },
+]
+
+[[package]]
 name = "tifffile"
 version = "2024.8.30"
 source = { registry = "https://pypi.org/simple" }
@@ -2614,6 +2685,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/43/d7e8b71f6c21ff813ee8da1006f89b6c7fff047fb4c8b16ceb5e840599c5/watchfiles-1.1.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:3dbd8cbadd46984f802f6d479b7e3afa86c42d13e8f0f322d669d79722c8ec34", size = 397286, upload-time = "2025-10-14T15:06:16.177Z" },
     { url = "https://files.pythonhosted.org/packages/1f/5d/884074a5269317e75bd0b915644b702b89de73e61a8a7446e2b225f45b1f/watchfiles-1.1.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5524298e3827105b61951a29c3512deb9578586abf3a7c5da4a8069df247cccc", size = 451768, upload-time = "2025-10-14T15:06:18.266Z" },
     { url = "https://files.pythonhosted.org/packages/17/71/7ffcaa9b5e8961a25026058058c62ec8f604d2a6e8e1e94bee8a09e1593f/watchfiles-1.1.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b943d3668d61cfa528eb949577479d3b077fd25fb83c641235437bc0b5bc60e", size = 458561, upload-time = "2025-10-14T15:06:19.323Z" },
+]
+
+[[package]]
+name = "waterbear"
+version = "2.6.8"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/3c/f1b41d47e038e922ae751d2dbddea1c5744ad79ab14d9bbec983d85afd0f/waterbear-2.6.8-py3-none-any.whl", hash = "sha256:e7c42bae01f4287eedde5bb71ab4671e93ca10edf3ebfba09a432ac4bace3f59", size = 9791, upload-time = "2023-09-03T18:38:06.505Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add path-based file access: `dxp.files("models").save(model, to="weights.pt")`
- Add glob pattern support for list/download/delete operations
- Add direct methods: `save_text()`, `save_json()`, `save_blob()`
- Add bindrs() placeholder for file collections
- Fix storage.py bug with undefined files_dir variable
- Maintain backwards compatibility with existing API

## New API Examples

```python
# Upload file to a prefix
dxp.files("checkpoints").save(net, to="checkpoint.pt")

# List files with glob pattern
files = dxp.files("images").list("*.png")

# Download with pattern
dxp.files("images").download("*.png", to="local_images")

# Delete files
dxp.files.delete("images/*.png")

# Convenience methods
dxp.files.save_text("content", to="view.yaml")
dxp.files.save_json({"key": "value"}, to="config.json")
dxp.files.save_blob(b"data", to="file.bin")
```

## Test plan
- [x] All existing file tests pass (40 tests)
- [x] New API tests pass (30 tests)
- [x] Backwards compatibility verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)