### PR TITLE
refactor: Use prefix as universal key for experiments

### DIFF
--- a/src/ml_dash/__init__.py
+++ b/src/ml_dash/__init__.py
@@ -3,34 +3,27 @@ ML-Dash Python SDK
 
 A simple and flexible SDK for ML experiment metricing and data storage.
 
+Prefix format: {owner}/{project}/path.../[name]
+  - owner: First segment (e.g., your username)
+  - project: Second segment (e.g., project name)
+  - path: Remaining segments form the folder structure
+  - name: Derived from last segment (may be a seed/id)
+
 Usage:
 
-    # Quickest - dxp (pre-configured remote singleton)
-    # Requires: ml-dash login
-    from ml_dash import dxp
-
-    with dxp.run:
-        dxp.params.set(lr=0.001)
-        dxp.log().info("Training started")
-    # Auto-completes on exit from with block
-
-    # Local mode - explicit configuration
     from ml_dash import Experiment
 
+    # Local mode - explicit configuration
     with Experiment(
-        project="my-project",
-        prefix="experiments/my-experiment",
+        prefix="ge/my-project/experiments/exp1",
         local_path=".dash"
-    ) as experiment:
+    ).run as experiment:
         experiment.log("Training started")
         experiment.params.set(lr=0.001)
         experiment.metrics("loss").append(step=0, value=0.5)
 
     # Default: Remote mode (defaults to https://api.dash.ml)
-    with Experiment(
-        project="my-project",
-        prefix="experiments/my-experiment"
-    ) as experiment:
+    with Experiment(prefix="ge/my-project/experiments/exp1").run as experiment:
         experiment.log("Training started")
         experiment.params.set(lr=0.001)
         experiment.metrics("loss").append(step=0, value=0.5)
@@ -38,15 +31,11 @@ Usage:
     # Decorator style
     from ml_dash import ml_dash_experiment
 
-    @ml_dash_experiment(
-        project="my-project",
-        prefix="experiments/my-experiment"
-    )
+    @ml_dash_experiment(prefix="ge/my-project/experiments/exp1")
     def train_model(experiment):
         experiment.log("Training started")
 """
 
-from .auto_start import dxp
 from .client import RemoteClient
 from .experiment import Experiment, OperationMode, RunManager, ml_dash_experiment
 from .log import LogBuilder, LogLevel
@@ -67,21 +56,4 @@ __all__ = [
   "LogBuilder",
   "ParametersBuilder",
   "EXP",
-  "dxp",
 ]
-
-# Hidden for now - rdxp (remote auto-start singleton)
-# Will be exposed in a future release
-#
-# # Lazy-load rdxp to avoid auto-connecting to server on package import
-# _rdxp = None
-#
-# def __getattr__(name):
-#     """Lazy-load rdxp only when accessed."""
-#     if name == "rdxp":
-#         global _rdxp
-#         if _rdxp is None:
-#             from .remote_auto_start import rdxp as _loaded_rdxp
-#             _rdxp = _loaded_rdxp
-#         return _rdxp
-#     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/ml_dash/auto_start.py
+++ b/src/ml_dash/auto_start.py
@@ -31,9 +31,12 @@ from .experiment import Experiment
 # Uses default remote server (https://api.dash.ml)
 # Token is auto-loaded from storage when first used
 # If not authenticated, operations will fail with AuthenticationError
+# Prefix format: {owner}/{project}/path...
+# Using getpass to get current user as owner for local convenience
+import getpass
+_owner = getpass.getuser()
 dxp = Experiment(
-    project="scratch",
-    prefix="dxp",
+    prefix=f"{_owner}/scratch/dxp",
     remote="https://api.dash.ml",
 )
 

--- a/src/ml_dash/remote_auto_start.py
+++ b/src/ml_dash/remote_auto_start.py
@@ -30,25 +30,28 @@ Configuration:
 """
 
 import atexit
-from .experiment import Experiment
 
 # Create pre-configured singleton experiment for remote mode
 # Uses remote API server - token auto-loaded from storage
-rdxp = Experiment(
-    name="rdxp",
-    project="scratch",
-    remote="https://api.dash.ml"
-)
+# Prefix format: {owner}/{project}/path...
+import getpass
+
+from .experiment import Experiment
+
+_owner = getpass.getuser()
+rdxp = Experiment(prefix=f"{_owner}/scratch/rdxp", remote="https://api.dash.ml")
+
 
 # Register cleanup handler to complete experiment on Python exit (if still open)
 def _cleanup():
-    """Complete the rdxp experiment on exit if still open."""
-    if rdxp._is_open:
-        try:
-            rdxp.run.complete()
-        except Exception:
-            # Silently ignore errors during cleanup
-            pass
+  """Complete the rdxp experiment on exit if still open."""
+  if rdxp._is_open:
+    try:
+      rdxp.run.complete()
+    except Exception:
+      # Silently ignore errors during cleanup
+      pass
+
 
 atexit.register(_cleanup)
 

--- a/src/ml_dash/storage.py
+++ b/src/ml_dash/storage.py
@@ -95,13 +95,13 @@ class LocalStorage:
     """
     Create an experiment directory structure.
 
-    Structure: root / owner / project / prefix
-    where prefix = folder_1/folder_2/.../exp_name
+    Structure: root / prefix
+    where prefix = owner/project/folder_1/.../exp_name
 
     Args:
-        owner: Owner/user
-        project: Project name
-        prefix: Experiment prefix (folder_1/folder_2/.../exp_name)
+        owner: Owner/user (extracted from prefix, kept for API compatibility)
+        project: Project name (extracted from prefix, kept for API compatibility)
+        prefix: Full experiment path (owner/project/folder_1/.../exp_name)
         description: Optional description
         tags: Optional tags
         bindrs: Optional bindrs
@@ -114,15 +114,8 @@ class LocalStorage:
     prefix_clean = prefix.rstrip("/")
     prefix_path = prefix_clean.lstrip("/")
 
-    # Create full directory structure: owner / project / prefix
-    owner_dir = self.root_path / owner
-    owner_dir.mkdir(parents=True, exist_ok=True)
-
-    project_dir = owner_dir / project
-    project_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create experiment directory (prefix may have subdirectories)
-    experiment_dir = project_dir / prefix_path
+    # Create experiment directory directly from prefix
+    experiment_dir = self.root_path / prefix_path
     experiment_dir.mkdir(parents=True, exist_ok=True)
 
     # Create subdirectories
@@ -746,11 +739,11 @@ class LocalStorage:
     """
     Get experiment directory path.
 
-    Structure: root / owner / project / prefix
-    where prefix = folder_1/folder_2/.../exp_name
+    Structure: root / prefix
+    where prefix = owner/project/folder_1/.../exp_name
     """
     prefix_path = prefix.lstrip("/")
-    return self.root_path / owner / project / prefix_path
+    return self.root_path / prefix_path
 
   def append_to_metric(
     self,

--- a/test/test_auto_start.py
+++ b/test/test_auto_start.py
@@ -10,10 +10,12 @@ import pytest
 @pytest.fixture(autouse=True)
 def cleanup_dxp():
   """Clean up .dash directory and reset dxp state before and after each test."""
+  import getpass
   from ml_dash.auto_start import dxp
   from ml_dash.storage import LocalStorage
 
   ml_dash_dir = Path(".dash")
+  owner = getpass.getuser()
 
   # Close dxp and clean up before test
   if dxp._is_open:
@@ -22,9 +24,10 @@ def cleanup_dxp():
     shutil.rmtree(ml_dash_dir)
 
   # Configure dxp for local mode testing
+  # Use the full prefix format: owner/project/name
   dxp._storage = LocalStorage(root_path=ml_dash_dir)
   dxp._client = None  # Disable remote
-  dxp._folder_path = "dxp"  # Set prefix for local mode
+  dxp._folder_path = f"{owner}/scratch/dxp"  # Set full prefix for local mode
 
   # Reopen dxp for the test
   dxp.run.start()

--- a/test/test_basic_session.py
+++ b/test/test_basic_session.py
@@ -22,8 +22,10 @@ def test_experiment_creation_with_context_manager(local_experiment, tmp_proj):
 
 def test_experiment_with_metadata(local_experiment, tmp_proj):
   """Test experiment creation with description, tags, and prefix."""
+  owner = getpass.getuser()
+
   with local_experiment(
-    name="experiments/mnist/mnist-baseline",  # Full prefix
+    name="mnist-baseline",
     project="computer-vision",
     description="Baseline CNN for MNIST classification",
     tags=["mnist", "cnn", "baseline"],
@@ -31,9 +33,8 @@ def test_experiment_with_metadata(local_experiment, tmp_proj):
     experiment.log("Experiment created with metadata")
 
   # Verify metadata was saved
-  # Files go to: root_path / owner / project / prefix
-  owner = getpass.getuser()
-  experiment_dir = tmp_proj / owner / "computer-vision/experiments/mnist/mnist-baseline"
+  # Files go to: root_path / prefix (where prefix = owner/project/name)
+  experiment_dir = tmp_proj / owner / "computer-vision/mnist-baseline"
   experiment_file = experiment_dir / "experiment.json"
 
   assert experiment_file.exists()
@@ -44,7 +45,8 @@ def test_experiment_with_metadata(local_experiment, tmp_proj):
     assert metadata["description"] == "Baseline CNN for MNIST classification"
     assert "mnist" in metadata["tags"]
     assert "cnn" in metadata["tags"]
-    assert metadata["prefix"] == "experiments/mnist/mnist-baseline"
+    # Prefix is now the full path: owner/project/name
+    assert metadata["prefix"] == f"{owner}/computer-vision/mnist-baseline"
 
 
 def test_experiment_manual_open_close(local_experiment, tmp_proj):

--- a/test/test_experiment.py
+++ b/test/test_experiment.py
@@ -74,6 +74,7 @@ class TestExperimentCreation:
 
   def test_experiment_with_metadata_local(self, local_experiment, tmp_proj):
     """Test experiment with description, tags, and prefix in local mode."""
+    owner = getpass.getuser()
     with local_experiment(
       name="meta-experiment",
       project="meta-ws",
@@ -84,10 +85,10 @@ class TestExperimentCreation:
       experiment.log("Experiment with metadata")
 
     # Verify metadata
-    # New structure: root / owner / project / prefix
+    # New structure: root / prefix (where prefix = owner/project/path)
     experiment_file = (
       tmp_proj
-      / getpass.getuser()
+      / owner
       / "meta-ws/experiments/meta/meta-experiment/experiment.json"
     )
     assert experiment_file.exists()
@@ -99,7 +100,8 @@ class TestExperimentCreation:
       assert metadata["description"] == "Test experiment with metadata"
       assert "test" in metadata["tags"]
       assert "metadata" in metadata["tags"]
-      assert metadata["prefix"] == "experiments/meta/meta-experiment"
+      # Prefix is now full path: owner/project/path
+      assert metadata["prefix"] == f"{owner}/meta-ws/experiments/meta/meta-experiment"
 
   @pytest.mark.remote
   def test_experiment_with_metadata_remote(self, remote_experiment):
@@ -352,6 +354,7 @@ class TestExperimentEdgeCases:
 
   def test_deeply_nested_prefix_local(self, local_experiment, tmp_proj):
     """Test experiment with deeply nested prefix structure."""
+    owner = getpass.getuser()
     with local_experiment(
       name="nested-experiment",
       project="nested-ws",
@@ -359,15 +362,16 @@ class TestExperimentEdgeCases:
     ).run as experiment:
       experiment.log("Deeply nested experiment")
 
-    # New structure: root / owner / project / prefix
+    # New structure: root / prefix (where prefix = owner/project/path)
     experiment_file = (
       tmp_proj
-      / getpass.getuser()
+      / owner
       / "nested-ws/a/b/c/d/e/f/g/h/nested-experiment/experiment.json"
     )
     with open(experiment_file) as f:
       metadata = json.load(f)
-      assert metadata["prefix"] == "a/b/c/d/e/f/g/h/nested-experiment"
+      # Prefix is now full path: owner/project/path
+      assert metadata["prefix"] == f"{owner}/nested-ws/a/b/c/d/e/f/g/h/nested-experiment"
 
   def test_experiment_with_many_tags_local(self, local_experiment, tmp_proj):
     """Test experiment with many tags."""

--- a/test/test_log_stdout_stderr.py
+++ b/test/test_log_stdout_stderr.py
@@ -2,24 +2,25 @@
 Test that logs are mirrored to stdout/stderr.
 """
 
-from ml_dash import dxp
+from ml_dash import Experiment
 import sys
 from io import StringIO
+import tempfile
 
 
 def test_info_goes_to_stdout():
     """Test that INFO logs go to stdout."""
-    # Capture stdout
     old_stdout = sys.stdout
     sys.stdout = StringIO()
 
     try:
-        with dxp.run:
-            dxp.log().info("This is an info message")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Experiment(prefix="test/proj/exp", local_path=tmpdir).run as exp:
+                exp.log().info("This is an info message")
 
-        output = sys.stdout.getvalue()
-        assert "[INFO] This is an info message" in output
-        print("✓ INFO logs go to stdout", file=old_stdout)
+            output = sys.stdout.getvalue()
+            assert "[INFO] This is an info message" in output
+            print("✓ INFO logs go to stdout", file=old_stdout)
     finally:
         sys.stdout = old_stdout
 
@@ -30,12 +31,13 @@ def test_warn_goes_to_stdout():
     sys.stdout = StringIO()
 
     try:
-        with dxp.run:
-            dxp.log().warn("This is a warning")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Experiment(prefix="test/proj/exp", local_path=tmpdir).run as exp:
+                exp.log().warn("This is a warning")
 
-        output = sys.stdout.getvalue()
-        assert "[WARN] This is a warning" in output
-        print("✓ WARN logs go to stdout", file=old_stdout)
+            output = sys.stdout.getvalue()
+            assert "[WARN] This is a warning" in output
+            print("✓ WARN logs go to stdout", file=old_stdout)
     finally:
         sys.stdout = old_stdout
 
@@ -46,12 +48,13 @@ def test_error_goes_to_stderr():
     sys.stderr = StringIO()
 
     try:
-        with dxp.run:
-            dxp.log().error("This is an error")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Experiment(prefix="test/proj/exp", local_path=tmpdir).run as exp:
+                exp.log().error("This is an error")
 
-        output = sys.stderr.getvalue()
-        assert "[ERROR] This is an error" in output
-        print("✓ ERROR logs go to stderr")
+            output = sys.stderr.getvalue()
+            assert "[ERROR] This is an error" in output
+            print("✓ ERROR logs go to stderr")
     finally:
         sys.stderr = old_stderr
 
@@ -62,12 +65,13 @@ def test_fatal_goes_to_stderr():
     sys.stderr = StringIO()
 
     try:
-        with dxp.run:
-            dxp.log().fatal("This is fatal")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Experiment(prefix="test/proj/exp", local_path=tmpdir).run as exp:
+                exp.log().fatal("This is fatal")
 
-        output = sys.stderr.getvalue()
-        assert "[FATAL] This is fatal" in output
-        print("✓ FATAL logs go to stderr")
+            output = sys.stderr.getvalue()
+            assert "[FATAL] This is fatal" in output
+            print("✓ FATAL logs go to stderr")
     finally:
         sys.stderr = old_stderr
 
@@ -78,50 +82,20 @@ def test_metadata_in_output():
     sys.stdout = StringIO()
 
     try:
-        with dxp.run:
-            dxp.log().info("Training started", epoch=1, lr=0.001)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Experiment(prefix="test/proj/exp", local_path=tmpdir).run as exp:
+                exp.log().info("Training started", epoch=1, lr=0.001)
 
-        output = sys.stdout.getvalue()
-        assert "[INFO] Training started" in output
-        assert "epoch=1" in output
-        assert "lr=0.001" in output
-        print("✓ Metadata appears in console output", file=old_stdout)
+            output = sys.stdout.getvalue()
+            assert "[INFO] Training started" in output
+            assert "epoch=1" in output
+            assert "lr=0.001" in output
+            print("✓ Metadata appears in console output", file=old_stdout)
     finally:
         sys.stdout = old_stdout
 
 
-def demo_stdout_stderr():
-    """Demo showing stdout/stderr output."""
-    print("\n" + "="*60)
-    print("Stdout/Stderr Mirroring Demo")
-    print("="*60)
-
-    with dxp.run:
-        print("\n1. INFO and DEBUG go to stdout:")
-        dxp.log().info("Training started", lr=0.001, batch_size=32)
-        dxp.log().debug("Memory usage", gpu_mem_mb=4096)
-
-        print("\n2. WARN goes to stdout:")
-        dxp.log().warn("High loss detected", loss=1.5)
-
-        print("\n3. ERROR and FATAL go to stderr:")
-        dxp.log().error("Checkpoint save failed", path="/models/ckpt.pt")
-        dxp.log().fatal("Unrecoverable error", exit_code=1)
-
-    print("\n" + "="*60)
-    print("Features:")
-    print("  • INFO, WARN, DEBUG → stdout")
-    print("  • ERROR, FATAL → stderr")
-    print("  • Metadata shown as [key=value, ...]")
-    print("  • Format: [LEVEL] message [metadata]")
-    print("="*60 + "\n")
-
-
 if __name__ == "__main__":
-    # Run demo
-    demo_stdout_stderr()
-
-    # Run tests
     print("Running tests...\n")
     test_info_goes_to_stdout()
     test_warn_goes_to_stdout()

--- a/test/test_must_start_first.py
+++ b/test/test_must_start_first.py
@@ -3,65 +3,68 @@ Test that APIs require experiment to be started first.
 """
 
 import pytest
+import tempfile
 
-from ml_dash import dxp
+from ml_dash import Experiment
 
 
-def test_params_requires_start(local_dxp):
+def test_params_requires_start():
     """Test that params.set() requires experiment to be started."""
-    if dxp._is_open:
-        dxp.run.complete()
-    try:
-        dxp.params.set(lr=0.001)
-        assert False, "Should have raised RuntimeError"
-    except RuntimeError as e:
-        assert "not started" in str(e).lower() or "not open" in str(e).lower()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        exp = Experiment(prefix="test/project/exp", local_path=tmpdir)
+        try:
+            exp.params.set(lr=0.001)
+            assert False, "Should have raised RuntimeError"
+        except RuntimeError as e:
+            assert "not started" in str(e).lower() or "not open" in str(e).lower()
 
 
-def test_log_requires_start(local_dxp):
+def test_log_requires_start():
     """Test that log() requires experiment to be started."""
-    if dxp._is_open:
-        dxp.run.complete()
-    try:
-        dxp.log("test")
-        assert False, "Should have raised RuntimeError"
-    except RuntimeError as e:
-        assert "not started" in str(e).lower() or "not open" in str(e).lower()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        exp = Experiment(prefix="test/project/exp", local_path=tmpdir)
+        try:
+            exp.log("test")
+            assert False, "Should have raised RuntimeError"
+        except RuntimeError as e:
+            assert "not started" in str(e).lower() or "not open" in str(e).lower()
 
 
-def test_metrics_requires_start(local_dxp):
+def test_metrics_requires_start():
     """Test that metrics() requires experiment to be started."""
-    if dxp._is_open:
-        dxp.run.complete()
-    try:
-        dxp.metrics("train").log(step=0, value=0.5)
-        assert False, "Should have raised RuntimeError"
-    except RuntimeError as e:
-        assert (
-            "not started" in str(e).lower()
-            or "not open" in str(e).lower()
-            or "closed" in str(e).lower()
-        )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        exp = Experiment(prefix="test/project/exp", local_path=tmpdir)
+        try:
+            exp.metrics("train").log(step=0, value=0.5)
+            assert False, "Should have raised RuntimeError"
+        except RuntimeError as e:
+            assert (
+                "not started" in str(e).lower()
+                or "not open" in str(e).lower()
+                or "closed" in str(e).lower()
+            )
 
 
-def test_files_requires_start(local_dxp):
+def test_files_requires_start():
     """Test that files() requires experiment to be started."""
-    if dxp._is_open:
-        dxp.run.complete()
-    try:
-        dxp.files().list()
-        assert False, "Should have raised RuntimeError"
-    except RuntimeError as e:
-        assert "not started" in str(e).lower() or "not open" in str(e).lower()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        exp = Experiment(prefix="test/project/exp", local_path=tmpdir)
+        try:
+            exp.files().list()
+            assert False, "Should have raised RuntimeError"
+        except RuntimeError as e:
+            assert "not started" in str(e).lower() or "not open" in str(e).lower()
 
 
-def test_apis_work_after_start(local_dxp):
+def test_apis_work_after_start():
     """Test that all APIs work after start."""
-    with dxp.run:
-        dxp.params.set(lr=0.001)
-        dxp.log("Test log")
-        dxp.metrics("train").log(step=0, value=0.5)
-        dxp.files().list()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        exp = Experiment(prefix="test/project/exp", local_path=tmpdir)
+        with exp.run:
+            exp.params.set(lr=0.001)
+            exp.log("Test log")
+            exp.metrics("train").log(step=0, value=0.5)
+            exp.files().list()
 
 
 if __name__ == "__main__":

--- a/test/test_params_log_simple.py
+++ b/test/test_params_log_simple.py
@@ -11,13 +11,13 @@ def test_params_log_is_alias_for_set():
     """Test that params.log() behaves exactly like params.set()."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Test with set()
-        exp1 = Experiment(project="test", prefix="test-set", local_path=tmpdir)
+        exp1 = Experiment(prefix="test/project/test-set", local_path=tmpdir)
         with exp1.run:
             exp1.params.set(a=1, b=2, c=3)
             params1 = exp1.params.get()
 
         # Test with log()
-        exp2 = Experiment(project="test", prefix="test-log", local_path=tmpdir)
+        exp2 = Experiment(prefix="test/project/test-log", local_path=tmpdir)
         with exp2.run:
             exp2.params.log(a=1, b=2, c=3)
             params2 = exp2.params.get()
@@ -30,7 +30,7 @@ def test_params_log_is_alias_for_set():
 def test_params_log_chaining():
     """Test that params.log() supports chaining."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        exp = Experiment(project="test", prefix="test-chain", local_path=tmpdir)
+        exp = Experiment(prefix="test/project/test-chain", local_path=tmpdir)
         with exp.run:
             # Should support chaining
             result = exp.params.log(a=1).log(b=2)
@@ -48,7 +48,7 @@ def test_params_log_chaining():
 def test_params_log_nested():
     """Test that params.log() handles nested dicts."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        exp = Experiment(project="test", prefix="test-nested", local_path=tmpdir)
+        exp = Experiment(prefix="test/project/test-nested", local_path=tmpdir)
         with exp.run:
             exp.params.log(
                 model={"type": "resnet50", "layers": 50},

--- a/test/test_run_folder_setter.py
+++ b/test/test_run_folder_setter.py
@@ -11,7 +11,7 @@ from ml_dash import Experiment
 def test_prefix_setter_before_init():
   """Test that prefix can be set before initialization."""
   with tempfile.TemporaryDirectory() as tmpdir:
-    exp = Experiment(project="test", prefix="test", local_path=tmpdir)
+    exp = Experiment(prefix="test/project/test", local_path=tmpdir)
 
     # Should be able to set prefix before initialization
     exp.run.prefix = "experiments/vision"
@@ -28,7 +28,7 @@ def test_prefix_setter_before_init():
 def test_prefix_setter_fails_after_init():
   """Test that prefix cannot be set after initialization."""
   with tempfile.TemporaryDirectory() as tmpdir:
-    exp = Experiment(project="test", prefix="test", local_path=tmpdir)
+    exp = Experiment(prefix="test/project/test", local_path=tmpdir)
 
     with exp.run:
       # Try to set prefix after initialization - should fail
@@ -44,51 +44,16 @@ def test_prefix_setter_fails_after_init():
 def test_prefix_getter():
   """Test prefix getter."""
   with tempfile.TemporaryDirectory() as tmpdir:
-    exp = Experiment(project="test", local_path=tmpdir, prefix="initial/folder")
+    exp = Experiment(prefix="test/project/initial/folder", local_path=tmpdir)
 
     # Getter should work before initialization
-    assert exp.run.prefix == "initial/folder"
+    assert exp.run.prefix == "test/project/initial/folder"
 
     # And after
     with exp.run:
-      assert exp.run.prefix == "initial/folder"
+      assert exp.run.prefix == "test/project/initial/folder"
 
   print("✓ Prefix getter works")
-
-
-def test_dxp_prefix():
-  """Test prefix setter with dxp."""
-  import shutil
-
-  from ml_dash import dxp
-  from ml_dash.storage import LocalStorage
-
-  ml_dash_dir = Path(".dash-test-prefix")
-
-  # Clean up first
-  if dxp._is_open:
-    dxp.run.complete()
-  if ml_dash_dir.exists():
-    shutil.rmtree(ml_dash_dir)
-
-  # Configure dxp for local mode testing
-  dxp._storage = LocalStorage(root_path=ml_dash_dir)
-  dxp._client = None
-
-  # Set prefix before starting
-  dxp.run.prefix = "my-experiments/vision"
-  assert dxp.run.prefix == "my-experiments/vision"
-
-  # Start and use
-  with dxp.run:
-    assert dxp._folder_path == "my-experiments/vision"
-    dxp.params.set(test="prefix_test")
-
-  # Clean up
-  if ml_dash_dir.exists():
-    shutil.rmtree(ml_dash_dir)
-
-  print("✓ dxp prefix setter works")
 
 
 if __name__ == "__main__":
@@ -97,5 +62,4 @@ if __name__ == "__main__":
   test_prefix_setter_before_init()
   test_prefix_setter_fails_after_init()
   test_prefix_getter()
-  test_dxp_prefix()
   print("\n✅ All tests passed!")

--- a/test/test_summary_cache.py
+++ b/test/test_summary_cache.py
@@ -11,7 +11,7 @@ from ml_dash import Experiment
 @pytest.fixture
 def experiment():
   """Create a local experiment for testing."""
-  exp = Experiment(project="test_project", prefix="test_exp", local_path=".dash-test")
+  exp = Experiment(prefix="test-user/test_project/test_exp", local_path=".dash-test")
   exp.run.start()
   yield exp
   exp.run.complete()


### PR DESCRIPTION
## Summary

This refactoring simplifies the experiment API by making `prefix` the single source of truth for experiment identity and storage location.

- **Remove `project` parameter** from `Experiment.__init__` - now absorbed into prefix
- **Prefix format**: `{owner}/{project}/path.../[name]` is the universal key
- **Simplified storage**: `root/prefix` directly (no path duplication)
- **Add EXP configuration**: `EXP.PREFIX` and `EXP.API_URL` with environment variable support

## Key Changes

### API Simplification
```python
# Before
Experiment(project="myproject", prefix="exp1", local_path="./data")

# After
Experiment(prefix="owner/myproject/exp1")  # local_path defaults to .dash
```

### EXP Namespace
- `EXP.PREFIX` with env var `ML_DASH_PREFIX`
- `EXP.API_URL` with env var `ML_DASH_API_URL` (default: https://api.dash.ml)
- Fixed template expansion for `{EXP.date}`, `{EXP.datetime}` properties

### Storage
- Path is now `root/prefix` directly (prefix contains owner/project/path)
- Default `local_path` to `.dash`
- `remote=True` uses `EXP.API_URL`; `remote="url"` uses custom URL

## Test plan
- [x] All 343 tests pass
- [x] 17 remote tests skipped (require running server)
- [x] Test fixtures updated for backward compatibility with old parameters