### PR TITLE
docs: Update Claude skills with current API patterns

### DIFF
--- a/.claude/skills/cli-commands.md
+++ b/.claude/skills/cli-commands.md
@@ -1,5 +1,5 @@
 ---
-description: ML-Dash CLI commands for authentication, uploading, downloading, and listing experiments
+description: ML-Dash CLI commands for authentication, creating projects, uploading, downloading, and listing experiments
 globs:
   - "**/*.sh"
   - "**/*.bash"
@@ -14,6 +14,7 @@ keywords:
   - upload
   - download
   - list
+  - create
   - authentication
   - OAuth
   - api-key
@@ -58,6 +59,23 @@ ml-dash upload --api-key your-jwt-token
 
 # Or config file ~/.dash/config.json
 {"remote_url": "https://api.dash.ml", "api_key": "your-jwt-token"}
+```
+
+---
+
+## Create Command
+
+Create projects on the remote server.
+
+```bash
+# Create a project in current user's namespace
+ml-dash create -p new-project
+
+# Create a project in a specific namespace
+ml-dash create -p geyang/new-project
+
+# Create with description
+ml-dash create -p geyang/tutorials -d "ML tutorials and examples"
 ```
 
 ---
@@ -194,6 +212,15 @@ ml-dash upload ./backup
 ml-dash list                              # See all experiments
 ml-dash list -p vision-models             # See specific project
 ml-dash download ./data -p "vision-models/resnet-50"
+```
+
+### Create Project Then Run Experiment
+```bash
+# Create project first
+ml-dash create -p geyang/new-research
+
+# Then run experiments
+python train.py  # Uses prefix="geyang/new-research/exp-name"
 ```
 
 ---

--- a/.claude/skills/params-proto.md
+++ b/.claude/skills/params-proto.md
@@ -133,7 +133,7 @@ class AugmentationConfig:
     flip_prob = 0.5
     color_jitter = 0.4
 
-with Experiment(prefix="alice/ml/resnet-training", project="cv").run as experiment:
+with Experiment(prefix="alice/ml/resnet-training").run as experiment:
     experiment.params.log(
         data=DataConfig,
         optimizer=OptimizerConfig,
@@ -150,7 +150,7 @@ class TrainingArgs:
     learning_rate = 0.001
     batch_size = 32
 
-with Experiment(prefix="alice/ml/hybrid-config", project="test").run as experiment:
+with Experiment(prefix="alice/ml/hybrid-config").run as experiment:
     experiment.params.log(
         training=TrainingArgs,  # Class object
         model={"name": "resnet50", "layers": 50},  # Dict
@@ -170,18 +170,18 @@ with Experiment(prefix="alice/ml/hybrid-config", project="test").run as experime
 Get parameters from logged class objects:
 
 ```python
-with Experiment(prefix="alice/ml/test", project="ml").run as experiment:
+with Experiment(prefix="alice/ml/test").run as experiment:
     experiment.params.log(training=TrainingConfig)
 
     # Retrieve flattened parameters
     params = experiment.params.get()
     print(params)
-    # → {"training.learning_rate": 0.001, "training.batch_size": 32, ...}
+    # -> {"training.learning_rate": 0.001, "training.batch_size": 32, ...}
 
     # Retrieve nested structure
     params_nested = experiment.params.get(flatten=False)
     print(params_nested)
-    # → {"training": {"learning_rate": 0.001, "batch_size": 32, ...}}
+    # -> {"training": {"learning_rate": 0.001, "batch_size": 32, ...}}
 
     # Access specific parameter
     lr = params["training.learning_rate"]
@@ -192,7 +192,7 @@ with Experiment(prefix="alice/ml/test", project="ml").run as experiment:
 Update class-based parameters during training:
 
 ```python
-with Experiment(prefix="alice/ml/lr-decay", project="training").run as experiment:
+with Experiment(prefix="alice/ml/lr-decay").run as experiment:
     # Initial parameters
     experiment.params.log(config=InitialConfig)
 
@@ -277,10 +277,3 @@ Parameters are stored in `parameters.json`:
 
 ### Remote Storage
 In remote mode, stored in MongoDB with the same flattened structure for easy querying.
-
-### API Access
-```python
-# Query your experiment
-experiment = dxp.experiment(name="my-exp", project="ml")
-params = experiment.params.get()
-```


### PR DESCRIPTION
## Summary
- Update all 6 Claude skill files to reflect current API patterns from tests and source code
- Add documentation for new tracks API for timestamped multi-modal data
- Add documentation for new fluent file API (`save_text`, `save_json`, `save_blob`)
- Add documentation for `ml-dash create` command
- Update metrics examples to use `.log()` instead of `.append()`
- Add background buffering documentation and environment variables

## Test plan
- [ ] Review skill files for accuracy against current codebase
- [ ] Verify examples match actual API usage in tests

cc @zehuaw1