### PR TITLE
fix(deps): drop params-proto <3.2.0 upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "cryptography>=42.0.0",
-    "params-proto>=3.0.0,<3.2.0",
+    "params-proto>=3.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## What

Remove the `<3.2.0` upper bound on `params-proto`:

```diff
-    "params-proto>=3.0.0,<3.2.0",
+    "params-proto>=3.0.0",
```

## Why

The cap makes `ml-dash` unsatisfiable for any project that requires `params-proto>=3.2` (current release is **3.3.0**). `uv sync` fails to resolve:

```
Because only ml-dash<=0.6.25 is available and ml-dash==0.6.25 depends on
params-proto>=3.0.0,<3.2.0 ... and because your project depends on
ml-dash>=0.6.25 and params-proto>=3.2, we can conclude that your project's
requirements are unsatisfiable.
```

`params-proto` 3.2+ is compatible with ml-dash, so widening the floor-only constraint to `>=3.0.0` unblocks downstream consumers.

## Follow-up

This only fixes the source constraint — a new release (version bump + `uv build && uv publish`) is needed before consumers can pull the fix from PyPI.