### PR TITLE
fix: single-source version + soften kill-switch (0.6.27)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml-dash"
-version = "0.6.25"
+version = "0.6.27"
 description = "ML experiment tracking and data storage"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -27,7 +27,7 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "cryptography>=42.0.0",
-    "params-proto>=3.0.0,<3.2.0",
+    "params-proto>=3.0.0",
 ]
 
 [project.scripts]

--- a/src/ml_dash/__init__.py
+++ b/src/ml_dash/__init__.py
@@ -51,15 +51,23 @@ from .params import ParametersBuilder
 from .run import RUN
 from .storage import LocalStorage
 
-__version__ = "0.6.25"
+# Single source of truth: derive the version from installed package metadata
+# (pyproject.toml) so the string is never duplicated and can never drift.
+try:
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+    __version__ = _pkg_version("ml-dash")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+unknown"
 
 
 def _check_version_compatibility():
     """
-    Enforce strict version requirement by checking against PyPI.
+    Warn (don't fail) if the installed version is older than the latest on PyPI.
 
-    Raises ImportError if installed version is older than the latest on PyPI.
-    This ensures all users are on the latest version with newest features and bug fixes.
+    Nudges users toward the newest release without bricking imports: a strict
+    ImportError here means a single bad/late publish takes down every older
+    install, and ties every import to network reachability.
     """
     try:
         from packaging import version
@@ -82,25 +90,13 @@ def _check_version_compatibility():
             latest = version.parse(latest_version)
 
             if current < latest:
-                raise ImportError(
-                    f"\n"
-                    f"{'=' * 80}\n"
-                    f"ERROR: ml-dash version {__version__} is outdated!\n"
-                    f"{'=' * 80}\n"
-                    f"\n"
-                    f"Your installed version ({__version__}) is no longer supported.\n"
-                    f"Latest version on PyPI: {latest_version}\n"
-                    f"\n"
-                    f"Please upgrade to the latest version:\n"
-                    f"\n"
-                    f"  pip install --upgrade ml-dash\n"
-                    f"\n"
-                    f"Or with uv:\n"
-                    f"\n"
-                    f"  uv pip install --upgrade ml-dash\n"
-                    f"  uv sync --upgrade-package ml-dash\n"
-                    f"\n"
-                    f"{'=' * 80}\n"
+                import warnings
+
+                warnings.warn(
+                    f"ml-dash {__version__} is behind the latest release "
+                    f"({latest_version}). Upgrade with `uv sync --upgrade-package "
+                    f"ml-dash` or `pip install --upgrade ml-dash`.",
+                    stacklevel=2,
                 )
     except (httpx.TimeoutException, httpx.ConnectError, KeyError):
         # Silently skip check if PyPI is unreachable or response is malformed

--- a/uv.lock
+++ b/uv.lock
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "ml-dash"
-version = "0.6.25"
+version = "0.6.27"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -911,7 +911,7 @@ requires-dist = [
     { name = "linkify-it-py", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=2.0.0" },
-    { name = "params-proto", specifier = ">=3.0.0,<3.2.0" },
+    { name = "params-proto", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "qrcode", marker = "extra == 'auth'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Why

`0.6.26` shipped with a stale hardcoded `__version__ = "0.6.25"` in `src/ml_dash/__init__.py` while `pyproject.toml` said `0.6.26`. The import-time `_check_version_compatibility()` queries PyPI and **raises `ImportError` if installed < latest** — so:

- **0.6.26** misreports itself as 0.6.25, sees latest 0.6.26 → raises. Dead on import.
- **0.6.25** also sees latest 0.6.26 → raises. Every published version became bricked on import for anyone online.

## What

- **Single source of truth:** derive `__version__` via `importlib.metadata.version("ml-dash")` so `pyproject.toml` is the only place the version lives — the two strings can no longer drift.
- **Soften the kill-switch:** strict `ImportError` → `warnings.warn`. A stale or offline install still imports instead of being bricked by a single bad/late publish.
- **Fix-forward to 0.6.27** (0.6.26 can't be overwritten on PyPI).

## Verify

```
import ml_dash; ml_dash.__version__  # -> '0.6.27', no ImportError
```

Unrelated WIP in the working tree (RTC docs/tests) is intentionally excluded.